### PR TITLE
Open Response upload file bug fix

### DIFF
--- a/src/main/webapp/wise5/components/openResponse/index.html
+++ b/src/main/webapp/wise5/components/openResponse/index.html
@@ -78,19 +78,13 @@
       </div>
     </div>
     <div ng-if='nodeController.getRevisions().length > 1' layout='row' layout-align='center end'>
-      <a ng-click='nodeController.showRevisions($event, component.id, openResponseController.isDisabled)'>
+      <a ng-click='nodeController.showRevisions($event, openResponseController.componentId, openResponseController.isDisabled)'>
          + {{ ::'openResponse.previousVersions' | translate }}: {{nodeController.getRevisions().length - 1}}
        </a>
     </div>
     <div class='component__actions' ng-if='::openResponseController.isStudentAttachmentEnabled' layout='row' layout-wrap='true'>
-      <div class='component__add-attachment'>
-        <md-button class='md-accent'
-               ng-click='nodeController.showStudentAssets($event, component.id, openResponseController.isDisabled)'
-               ng-disabled='openResponseController.isDisabled'>
-          <md-icon>image</md-icon> <span>{{ ::'openResponse.addFile' | translate }}</span>
-        </md-button>
-      </div>
       <div class='component__attachment' ng-repeat='attachment in openResponseController.attachments'>
+
         <img ng-src='{{attachment.iconURL}}' class='component__attachment__content' />
         <md-button ng-if='!openResponseController.isDisabled' class='component__attachment__delete'
                    ng-click='openResponseController.removeAttachment(attachment)' title='Remove file'
@@ -98,8 +92,14 @@
           <md-icon>cancel</md-icon>
         </md-button>
       </div>
+      <div class='component__add-attachment'>
+        <md-button class='md-accent'
+               ng-click='nodeController.showStudentAssets($event, openResponseController.componentId, openResponseController.isDisabled)'
+               ng-disabled='openResponseController.isDisabled'>
+          <md-icon>image</md-icon> <span>{{ ::'openResponse.addFile' | translate }}</span>
+        </md-button>
+      </div>
     </div>
-    {{openResponseController.echoResponse.echoResponse}}
     <div ng-if='::openResponseController.isSaveOrSubmitButtonVisible()'
        class='component__actions' layout='row' layout-align='start center'>
       <md-button id='saveButton'


### PR DESCRIPTION
This fixes the issue where student upload dialog in the Open Response component was not showing up when you clicked on the "Add File" button.

How to test:
1. Create an open response component, and set its isStudentAttachmentEnabled flag to true in the JSON authoring mode.
```
...
isStudentAttachmentEnabled: true,
...
```
2. Create a run with the unit.
3. Launch the run as a student, go to the open response component, and try to upload images. They should appear and be saved along with the text content.