### PR TITLE
Show ta tool button based on flag in project metadata

### DIFF
--- a/src/main/webapp/site/src/app/domain/run.ts
+++ b/src/main/webapp/site/src/app/domain/run.ts
@@ -88,6 +88,10 @@ export class Run {
     return false;
   }
 
+  isTAToolEnabled() {
+    return JSON.parse(this.project.metadata.tools).isTAToolEnabled;
+  }
+
   hasEndTime() {
     return this.endTime != null;
   }

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
@@ -37,7 +37,7 @@
         <mat-card-title [class.secondary-text]="isRunCompleted(run)" class="mat-body-2">
           {{run.project.name}}
           <span *ngIf="run.project.wiseVersion === 4"
-                class="warn mat-caption more-info" 
+                class="warn mat-caption more-info"
                 tabindex="0"
                 i18n-matTooltip
                 matTooltip="This unit is from an old version of WISE that is no longer supported. Please find an alternate unit to use in the future or contact us for upgrade options."
@@ -80,6 +80,14 @@
          fxFlex="0 0 auto"
          fxFlex.xs="100">
         <mat-icon>assignment_turned_in</mat-icon>&nbsp;<ng-container i18n>Teacher Tools</ng-container>
+      </a>
+      <a *ngIf="(isRunActive(run) || isRunCompleted(run)) && run.isTAToolEnabled()"
+         mat-flat-button
+         href="{{taToolsLink}}"
+         color="primary"
+         fxFlex="0 0 auto"
+         fxFlex.xs="100">
+        <mat-icon>assignment_turned_in</mat-icon>&nbsp;<ng-container i18n>TA Tools</ng-container>
       </a>
     </div>
   </mat-card-actions>

--- a/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
@@ -21,6 +21,7 @@ export class TeacherRunListItemComponent implements OnInit {
   editLink: string = '';
   gradeAndManageLink: string = '';
   manageStudentsLink: string = '';
+  taToolsLink: string = '';
   thumbStyle: SafeStyle;
   animateDuration: string = '0s';
   animateDelay: string = '0s';
@@ -44,6 +45,7 @@ export class TeacherRunListItemComponent implements OnInit {
     if (this.run != null) {
       this.gradeAndManageLink = `${this.configService.getContextPath()}/teacher/run/manage/${this.run.id}#!/run/${this.run.id}/project/`;
       this.manageStudentsLink = `${this.configService.getContextPath()}/teacher/run/manage/${this.run.id}#!/run/${this.run.id}/manageStudents`;
+      this.taToolsLink = `${this.configService.getContextPath()}/score-ta`;
       if (this.run.isHighlighted) {
         this.animateDuration = '2s';
         this.animateDelay = '1s';


### PR DESCRIPTION
When project.metadata.tools.isTAToolEnabled is set to true, the TA tools button will be displayed in the teacher run listing page. Clicking on it will launch the TA app.

How to test:
1. Edit the content of an existing run with the Authoring Tool.
2. Go to the advanced editing view
<img width="529" alt="Screen Shot 2020-02-03 at 7 11 05 PM" src="https://user-images.githubusercontent.com/119416/73710602-59efc000-46b9-11ea-9bf9-887fc2832ddd.png">
3. Open JSON editing
<img width="745" alt="Screen Shot 2020-02-03 at 7 12 00 PM" src="https://user-images.githubusercontent.com/119416/73710593-54927580-46b9-11ea-95b1-e60458500250.png">
4. Find the metadata section, and add  `isTAToolEnabled: true`
<img width="190" alt="Screen Shot 2020-02-03 at 7 16 57 PM" src="https://user-images.githubusercontent.com/119416/73710824-e8fcd800-46b9-11ea-8e05-f6f1e271d867.png">
5. Save the unit and go back to the teacher run listing page. The TA button should appear in the run.
<img width="911" alt="Screen Shot 2020-02-03 at 7 18 18 PM" src="https://user-images.githubusercontent.com/119416/73710902-16498600-46ba-11ea-92bf-f821f6399dd7.png">
6. Click on the button. It should launch the TA app.
