### PR TITLE
Discussion post gating option

### DIFF
--- a/src/main/webapp/wise5/components/discussion/authoring.html
+++ b/src/main/webapp/wise5/components/discussion/authoring.html
@@ -208,6 +208,13 @@
           {{ ::'discussion.allowUploadedImagesInPosts' | translate }}
         </md-checkbox>
       </md-input-container>
+      <br/>
+      <md-input-container style='margin-top: 0; margin-bottom: 0;'>
+        <md-checkbox ng-model='discussionController.authoringComponentContent.gateClassmateResponses'
+                     ng-change='discussionController.authoringViewComponentChanged()'>
+          {{ ::'discussion.gateClassmateResponses' | translate }}
+        </md-checkbox>
+      </md-input-container>
     </div>
   </div>
   <div ng-style='discussionController.mode === "authoring" && {"border": "5px solid black", "padding": "20px"}'>

--- a/src/main/webapp/wise5/components/discussion/i18n/i18n_en.json
+++ b/src/main/webapp/wise5/components/discussion/i18n/i18n_en.json
@@ -1,9 +1,10 @@
 {
-  "discussion.allowUploadedImagesInPosts": "Students can upload and use images in their posts.",
+  "discussion.allowUploadedImagesInPosts": "Students can upload and use images in their posts",
   "discussion.areYouSureYouWantToDeleteThisPost": "Are you sure you want to delete this post?",
   "discussion.areYouSureYouWantToShowThisPost": "Are you sure you want to show this post?",
   "discussion.comments": "Comments",
   "discussion.componentTypeLabel": "Discussion",
+  "discussion.gateClassmateResponses": "Students must create a post before viewing classmates' posts",
   "discussion.post": "Post",
   "discussion.repliedToADiscussionYouWereIn": "{{usernames}} replied to a discussion you were in!",
   "discussion.reply": "Reply",


### PR DESCRIPTION
This commit allows authors to allow/disallow students to seeing other students' posts before creating new post in discussion component. The JSON field is called ```gateClassmateResponses```.

Test that you can 
- enable/disable the ```gateClassmateResponses``` option in the discussion component authoring
- see others' posts without creating a new post if gating is disabled (```gateClassmateResponses=false```)
- NOT see others' posts without creating a new post if gating is enabled (```gateClassmateResponses=true```)

Resolves #26