### PR TITLE
Discussion isVotingAllowed flag 

### DIFF
--- a/src/main/webapp/wise5/components/discussion/authoring.html
+++ b/src/main/webapp/wise5/components/discussion/authoring.html
@@ -215,6 +215,13 @@
           {{ ::'discussion.gateClassmateResponses' | translate }}
         </md-checkbox>
       </md-input-container>
+      <br/>
+      <md-input-container style='margin-top: 0; margin-bottom: 0;'>
+        <md-checkbox ng-model='discussionController.authoringComponentContent.isVotingAllowed'
+                     ng-change='discussionController.authoringViewComponentChanged()'>
+          {{ ::'discussion.allowVoting' | translate }}
+        </md-checkbox>
+      </md-input-container>
     </div>
   </div>
   <div ng-style='discussionController.mode === "authoring" && {"border": "5px solid black", "padding": "20px"}'>

--- a/src/main/webapp/wise5/components/discussion/classResponse.html
+++ b/src/main/webapp/wise5/components/discussion/classResponse.html
@@ -24,7 +24,7 @@
     </div>
     <img ng-repeat='attachment in ::classResponseCtrl.response.studentData.attachments'
       ng-src='{{::attachment.iconURL}}' alt='Image' class='discussion-post__attachment' />
-      <div layout='row' layout-align='end center'>
+    <div layout='row' layout-align='end center' ng-if='::classResponseCtrl.isvotingallowed'>
         <md-button ng-class="classResponseCtrl.isUpvoteClicked ? 'md-accent' : ''"
           ng-click='classResponseCtrl.upvoteClicked(classResponseCtrl.response)'>
         <md-icon>thumb_up</md-icon>
@@ -109,7 +109,7 @@
     <div class='discussion-new-reply' flex layout='row'
       ng-if='::(classResponseCtrl.mode === "student" && !classResponseCtrl.isdisabled)'>
       <md-input-container class='input-container discussion-new-reply__input-container md-block' md-no-float flex>
-        <textarea class='input--textarea discussion-reply__input' 
+        <textarea class='input--textarea discussion-reply__input'
           ng-model='::classResponseCtrl.response.replyText'
           ng-keyup="classResponseCtrl.replyEntered($event)"
           placeholder='{{ ::"addComment" | translate }}'

--- a/src/main/webapp/wise5/components/discussion/classResponse.js
+++ b/src/main/webapp/wise5/components/discussion/classResponse.js
@@ -170,7 +170,8 @@ const ClassResponseComponentOptions = {
     createunvoteannotation: '&',
     submitbuttonclicked: '&',
     studentdatachanged: '&',
-    isdisabled: '<'
+    isdisabled: '<',
+    isvotingallowed: '<'
   },
   templateUrl: 'wise5/components/discussion/classResponse.html',
   controller: 'ClassResponseController as classResponseCtrl'

--- a/src/main/webapp/wise5/components/discussion/discussionController.js
+++ b/src/main/webapp/wise5/components/discussion/discussionController.js
@@ -36,7 +36,10 @@ class DiscussionController extends ComponentController {
     this.topLevelResponses = [];
     this.responsesMap = {};
     this.retrievedClassmateResponses = false;
-    this.sortOptions = ["newest", "oldest", "mostPopular", "leastPopular"];
+    this.sortOptions = ["newest", "oldest"];
+    if (this.isVotingAllowed()) {
+      this.sortOptions = this.sortOptions.concat(["mostPopular", "leastPopular"]);
+    }
     this.sortPostsBy = "newest";
     if (this.isStudentMode()) {
       if (this.ConfigService.isPreview()) {
@@ -415,6 +418,10 @@ class DiscussionController extends ComponentController {
 
   isClassmateResponsesGated() {
     return this.componentContent.gateClassmateResponses;
+  }
+
+  isVotingAllowed() {
+    return this.componentContent.isVotingAllowed;
   }
 
   setClassResponses(componentStates, annotations = []) {

--- a/src/main/webapp/wise5/components/discussion/discussionService.js
+++ b/src/main/webapp/wise5/components/discussion/discussionService.js
@@ -34,6 +34,7 @@ class DiscussionService extends ComponentService {
     component.prompt = this.$translate('ENTER_PROMPT_HERE');
     component.isStudentAttachmentEnabled = true;
     component.gateClassmateResponses = true;
+    component.isVotingAllowed = false;
     return component;
   }
 

--- a/src/main/webapp/wise5/components/discussion/i18n/i18n_en.json
+++ b/src/main/webapp/wise5/components/discussion/i18n/i18n_en.json
@@ -1,5 +1,6 @@
 {
   "discussion.allowUploadedImagesInPosts": "Students can upload and use images in their posts",
+  "discussion.allowVoting": "Students can vote on posts",
   "discussion.areYouSureYouWantToDeleteThisPost": "Are you sure you want to delete this post?",
   "discussion.areYouSureYouWantToShowThisPost": "Are you sure you want to show this post?",
   "discussion.comments": "Comments",

--- a/src/main/webapp/wise5/components/discussion/index.html
+++ b/src/main/webapp/wise5/components/discussion/index.html
@@ -151,6 +151,7 @@
                   createunvoteannotation='discussionController.createunvoteannotation(componentState)'
                   studentdatachanged='studentdatachanged()'
                   isdisabled='::discussionController.isDisabled'
+                  isvotingallowed='::discussionController.isVotingAllowed()'
                   class='post animate-repeat'>
               </class-response>
               <class-response ng-repeat='componentState in discussionController.topLevelResponses.col2'
@@ -166,6 +167,7 @@
                   createunvoteannotation='discussionController.createunvoteannotation(componentState)'
                   studentdatachanged='studentdatachanged()'
                   isdisabled='::discussionController.isDisabled'
+                  isvotingallowed='::discussionController.isVotingAllowed()'
                   class='post animate-repeat'>
               </class-response>
             </div>
@@ -182,6 +184,7 @@
                   createunvoteannotation='discussionController.createunvoteannotation(componentState)'
                   studentdatachanged='studentdatachanged()'
                   isdisabled='::discussionController.isDisabled'
+                  isvotingallowed='::discussionController.isVotingAllowed()'
                   class='animate-repeat'
                   style='display: block;'>
               </class-response>


### PR DESCRIPTION
This commit allows authors to allow/disallow students to vote on other students' posts. The JSON field is called ```isVotingAllowed```.

Test that you can
- enable/disable the voting option in the discussion component authoring
- see voting features (upvote, downvote buttons, vote tally, sort-by-votes choices) if voting is enabled (```isVotingAllowed=true```)
- NOT see voting features if voting is disabled (```isVotingAllowed=false```)

Resolves #37