### PR TITLE
Set OpenResponse component to complete if student attaches a file

### DIFF
--- a/src/main/webapp/wise5/components/openResponse/openResponseService.js
+++ b/src/main/webapp/wise5/components/openResponse/openResponseService.js
@@ -44,7 +44,7 @@ class OpenResponseService extends ComponentService {
         let studentData = componentState.studentData;
 
         if (studentData != null) {
-          if (studentData.response) {
+          if (studentData.response || studentData.attachments.length > 0) {
             // there is a response so the component is completed
             result = true;
           }
@@ -110,7 +110,8 @@ class OpenResponseService extends ComponentService {
 
   hasResponse(componentState) {
     const response = componentState.studentData.response;
-    return response != null && response !== '';
+    const attachments = componentState.studentData.attachments;
+    return (response != null && response !== '') || attachments.length > 0;
   }
 }
 


### PR DESCRIPTION
Also fixed issue where previous attachments were not displaying below the textarea. 

Test the following:
- When OR component student attachment is enabled:
   - student types in response only => complete
   - student attaches only => complete
   - student types in response and attaches => complete
   - student does not type in response and does not attach => incomplete
- When OR component student attachment is disabled:
   - student does nothing => incomplete
   - student types in response => complete
   - student does not type in response => incomplete

Also test that the attachment shows up when you leave the step and come back. This was a bug that I found while working on this feature.

Resolves #46