### PR TITLE
Implemented randomly allocating students to periods

### DIFF
--- a/src/main/java/org/wise/portal/domain/run/Run.java
+++ b/src/main/java/org/wise/portal/domain/run/Run.java
@@ -381,6 +381,10 @@ public interface Run extends Persistable {
    */
   void setSurvey(String survey);
 
+  void setRandomPeriodAssignment(boolean isRandomPeriodAssignment);
+
+  boolean isRandomPeriodAssignment();
+
   Long getStartTimeMilliseconds();
 
   Long getEndTimeMilliseconds();

--- a/src/main/java/org/wise/portal/domain/run/impl/RunImpl.java
+++ b/src/main/java/org/wise/portal/domain/run/impl/RunImpl.java
@@ -249,6 +249,11 @@ public class RunImpl implements Run {
   @Setter
   private String survey;   // text (blob) 2^15
 
+  @Column(name = "isRandomPeriodAssignment")
+  @Getter
+  @Setter
+  private boolean isRandomPeriodAssignment = false;
+
   public Group getPeriodByName(String periodName) throws PeriodNotFoundException {
     Set<Group> periods = getPeriods();
     for (Group period : periods) {

--- a/src/main/java/org/wise/portal/domain/run/impl/RunParameters.java
+++ b/src/main/java/org/wise/portal/domain/run/impl/RunParameters.java
@@ -46,6 +46,8 @@ public class RunParameters implements Serializable {
 
   private Set<String> periodNames = new TreeSet<String>();
 
+  private boolean isRandomPeriodAssignment = false;
+
   private Set<String> runIdsToArchive = new TreeSet<String>();
 
   private User owner;

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
@@ -136,6 +136,7 @@ public class StudentAPIController extends UserAPIController {
     info.put("startTime", run.getStartTimeMilliseconds());
     info.put("endTime", run.getEndTimeMilliseconds());
     info.put("periods", getPeriodNames(run));
+    info.put("isRandomPeriodAssignment", run.isRandomPeriodAssignment());
     User owner = run.getOwner();
     info.put("teacherFirstName", owner.getUserDetails().getFirstname());
     info.put("teacherLastName", owner.getUserDetails().getLastname());

--- a/src/main/java/org/wise/portal/service/run/RunService.java
+++ b/src/main/java/org/wise/portal/service/run/RunService.java
@@ -56,8 +56,8 @@ public interface RunService {
    */
   Run createRun(RunParameters runParameters) throws ObjectNotFoundException;
 
-  Run createRun(Long projectId, User user, Set<String> periodNames, Integer maxStudentsPerTeam,
-      Long startDate, Long endDate, Locale locale) throws Exception;
+  Run createRun(Long projectId, User user, Set<String> periodNames, boolean isRandomPeriodAssignment,
+      Integer maxStudentsPerTeam, Long startDate, Long endDate, Locale locale) throws Exception;
 
   /**
    * Ends this run. The side effect is that the run's endtime gets set.
@@ -451,4 +451,6 @@ public interface RunService {
 
   JSONObject transferRunOwnership(Long runId, String teacherUsername)
       throws ObjectNotFoundException;
+
+  void setRandomPeriodAssignment(Run run, boolean isRandomPeriodAssignment);
 }

--- a/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
@@ -210,6 +210,7 @@ public class RunServiceImpl implements RunService {
       }
       run.setPeriods(periods);
     }
+    run.setRandomPeriodAssignment(runParameters.isRandomPeriodAssignment());
     run.setPostLevel(runParameters.getPostLevel());
 
     Boolean enableRealTime = runParameters.getEnableRealTime();
@@ -231,18 +232,18 @@ public class RunServiceImpl implements RunService {
     return run;
   }
 
-  public Run createRun(Long projectId, User user, Set<String> periodNames,
+  public Run createRun(Long projectId, User user, Set<String> periodNames, boolean isRandomPeriodAssignment,
         Integer maxStudentsPerTeam, Long startDate, Long endDate, Locale locale) throws Exception {
     Project project = projectService.copyProject(projectId, user);
     RunParameters runParameters = createRunParameters(project, user, periodNames,
-        maxStudentsPerTeam, startDate, endDate, locale);
+        isRandomPeriodAssignment, maxStudentsPerTeam, startDate, endDate, locale);
     Run run = createRun(runParameters);
     createTeacherWorkgroup(run, user);
     return run;
   }
 
   public RunParameters createRunParameters(Project project, User user, Set<String> periodNames,
-        Integer maxStudentsPerTeam, Long startDate, Long endDate, Locale locale) {
+        boolean isRandomPeriodAssignment, Integer maxStudentsPerTeam, Long startDate, Long endDate, Locale locale) {
     RunParameters runParameters = new RunParameters();
     runParameters.setOwner(user);
     runParameters.setName(project.getName());
@@ -250,6 +251,7 @@ public class RunServiceImpl implements RunService {
     runParameters.setLocale(locale);
     runParameters.setPostLevel(5);
     runParameters.setPeriodNames(periodNames);
+    runParameters.setRandomPeriodAssignment(isRandomPeriodAssignment);
     runParameters.setMaxWorkgroupSize(maxStudentsPerTeam);
     runParameters.setStartTime(new Date(startDate));
     if (endDate == null || endDate <= startDate) {
@@ -791,6 +793,12 @@ public class RunServiceImpl implements RunService {
 
   public boolean isAllowedToViewStudentNames(Run run, User user) {
     return hasRunPermission(run, user, RunPermission.VIEW_STUDENT_NAMES);
+  }
+
+  @Override
+  public void setRandomPeriodAssignment(Run run, boolean isRandomPeriodAssignment) {
+    run.setRandomPeriodAssignment(isRandomPeriodAssignment);
+    runDao.save(run);
   }
 
 }

--- a/src/main/resources/wise_db_init.sql
+++ b/src/main/resources/wise_db_init.sql
@@ -501,6 +501,7 @@ create table runs
     id               bigint       not null auto_increment,
     owner_fk         bigint       not null,
     project_fk       bigint       not null,
+    isRandomPeriodAssignment bit not null,
     constraint runsOwnerFK foreign key (owner_fk) references users (id),
     constraint runsProjectFK foreign key (project_fk) references projects (id),
     constraint runsRunCodeUnique unique (run_code),

--- a/src/main/webapp/site/src/app/domain/run.ts
+++ b/src/main/webapp/site/src/app/domain/run.ts
@@ -9,6 +9,7 @@ export class Run {
   runCode: string;
   startTime: number;
   endTime: number;
+  isRandomPeriodAssignment: boolean;
   lastRun: string;
   projectThumb: string;
   numStudents: number;

--- a/src/main/webapp/site/src/app/student/add-project-dialog/add-project-dialog.component.html
+++ b/src/main/webapp/site/src/app/student/add-project-dialog/add-project-dialog.component.html
@@ -1,6 +1,6 @@
 <h2 i18n>Add Unit</h2>
 <form [formGroup]="addProjectForm">
-  <mat-dialog-content fxLayout="column">
+  <mat-dialog-content fxLayout="column" style="padding: 16px">
     <p>
       <mat-form-field appearance="fill">
         <mat-label i18n>Access Code</mat-label>
@@ -16,6 +16,7 @@
         <mat-select formControlName="period" [(value)]="selectedPeriod">
           <mat-option *ngFor="let period of registerRunPeriods" value="{{ period }}">{{ period }}</mat-option>
         </mat-select>
+        <mat-hint *ngIf="isRandomlyAssignedPeriod" i18n>You have been randomly assigned to a period.</mat-hint>
       </mat-form-field>
     </p>
   </mat-dialog-content>

--- a/src/main/webapp/site/src/app/student/add-project-dialog/add-project-dialog.component.ts
+++ b/src/main/webapp/site/src/app/student/add-project-dialog/add-project-dialog.component.ts
@@ -22,6 +22,7 @@ export class AddProjectDialogComponent implements OnInit {
     period: new FormControl({value: '', disabled: true}, Validators.required)
   });
   isAdding = false;
+  isRandomlyAssignedPeriod = false;
 
   constructor(public dialog: MatDialog,
               private studentService: StudentService,
@@ -71,13 +72,25 @@ export class AddProjectDialogComponent implements OnInit {
           this.clearPeriods();
           this.addProjectForm.controls['runCode'].setErrors({'invalidRunCode': true});
         } else {
-          this.registerRunPeriods = runInfo.periods;
-          this.addProjectForm.controls['period'].enable();
+          this.clearPeriods();
+          if (runInfo.isRandomPeriodAssignment) {
+            this.selectedPeriod = this.chooseRandom(runInfo.periods);
+            this.registerRunPeriods.push(this.selectedPeriod);
+            this.addProjectForm.controls['period'].setValue(this.selectedPeriod);
+            this.isRandomlyAssignedPeriod = true;
+          } else {
+            this.registerRunPeriods = runInfo.periods;
+            this.addProjectForm.controls['period'].enable();
+          }
         }
       });
     } else {
       this.clearPeriods();
     }
+  }
+
+  chooseRandom(periods: string[]): string {
+    return periods[Math.floor(Math.random() * periods.length)];
   }
 
   isValidRunCodeSyntax(runCode: string) {

--- a/src/main/webapp/site/src/app/student/run-info.ts
+++ b/src/main/webapp/site/src/app/student/run-info.ts
@@ -1,4 +1,5 @@
 export class RunInfo {
+  isRandomPeriodAssignment: boolean = false;
   periods: string[];
   runCode: string;
   runId: number;

--- a/src/main/webapp/site/src/app/student/student-home/student-home.component.ts
+++ b/src/main/webapp/site/src/app/student/student-home/student-home.component.ts
@@ -28,6 +28,8 @@ export class StudentHomeComponent implements OnInit {
   }
 
   showAddRun() {
-    this.dialog.open(AddProjectDialogComponent);
+    this.dialog.open(AddProjectDialogComponent, {
+      maxHeight: '500vh'
+    });
   }
 }

--- a/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.html
+++ b/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.html
@@ -21,6 +21,12 @@
              formControlName="customPeriods" />
       <mat-hint i18n>For "Period 9", just enter the number 9. Separate periods with commas (e.g. "Section 1, Section 2"). Manually named periods should be no more than 16 characters long.</mat-hint>
     </mat-form-field>
+    <p></p>
+    <p>
+    <mat-checkbox formControlName="isRandomPeriodAssignment" i18n>
+       Randomly assign students to periods
+    </mat-checkbox>
+    </p>
     <mat-divider></mat-divider>
     <h3 i18n>2. Choose Students Per Team</h3>
     <mat-radio-group #rGroup
@@ -82,5 +88,5 @@
   <mat-dialog-actions fxLayoutAlign="end">
     <button mat-button color="primary" (click)="checkClassroomAuthorization()" *ngIf="isGoogleUser() && isGoogleClassroomEnabled()" i18n>Add to Google Classroom</button>
     <button mat-button (click)="closeAll()" i18n>Done</button>
-  </mat-dialog-actions> 
+  </mat-dialog-actions>
 </ng-container>

--- a/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.ts
+++ b/src/main/webapp/site/src/app/teacher/create-run-dialog/create-run-dialog.component.ts
@@ -57,6 +57,7 @@ export class CreateRunDialogComponent {
     this.form = this.fb.group({
       selectedPeriods: this.periodsGroup,
       customPeriods: this.customPeriods,
+      isRandomPeriodAssignment: new FormControl(false),
       periods: hiddenControl,
       maxStudentsPerTeam: new FormControl('3', Validators.required),
       startDate: new FormControl(new Date(), Validators.required),
@@ -99,8 +100,9 @@ export class CreateRunDialogComponent {
       endDate = endDateValue.getTime();
     }
     const maxStudentsPerTeam = this.form.controls['maxStudentsPerTeam'].value;
+    const isRandomPeriodAssignment = this.form.controls['isRandomPeriodAssignment'].value;
     this.teacherService.createRun(
-        this.project.id, combinedPeriods, maxStudentsPerTeam, startDate, endDate)
+        this.project.id, combinedPeriods, isRandomPeriodAssignment, maxStudentsPerTeam, startDate, endDate)
         .pipe(
           finalize(() => {
             this.isCreating = false;

--- a/src/main/webapp/site/src/app/teacher/run-settings-dialog/run-settings-dialog.component.html
+++ b/src/main/webapp/site/src/app/teacher/run-settings-dialog/run-settings-dialog.component.html
@@ -25,6 +25,12 @@
       <mat-hint *ngIf="addPeriodMessage" class="warn">{{ addPeriodMessage }}</mat-hint>
     </mat-form-field>
   </div>
+  <p></p>
+  <p>
+  <mat-checkbox [checked]="isRandomPeriodAssignment" (change)="updateRandomPeriodAssignment($event.checked)" i18n>
+      Randomly assign students to periods
+  </mat-checkbox>
+  </p>
   <mat-divider></mat-divider>
   <h3 i18n>Students Per Team</h3>
   <mat-radio-group [(ngModel)]="maxStudentsPerTeam" #rGroup fxLayoutGap="16px">

--- a/src/main/webapp/site/src/app/teacher/run-settings-dialog/run-settings-dialog.component.ts
+++ b/src/main/webapp/site/src/app/teacher/run-settings-dialog/run-settings-dialog.component.ts
@@ -23,6 +23,7 @@ export class RunSettingsDialogComponent implements OnInit {
   previousEndDate: Date;
   deletePeriodMessage: string = '';
   addPeriodMessage: string = '';
+  isRandomPeriodAssignment: boolean;
   maxStudentsPerTeamMessage: string = '';
   startDateMessage: string = '';
   endDateMessage: string = '';
@@ -48,6 +49,7 @@ export class RunSettingsDialogComponent implements OnInit {
               private i18n: I18n) {
     this.run = data.run;
     this.maxStudentsPerTeam = this.run.maxStudentsPerTeam + '';
+    this.isRandomPeriodAssignment = this.run.isRandomPeriodAssignment;
     this.startDate = new Date(this.run.startTime);
     this.endDate = this.run.endTime ? new Date(this.run.endTime) : null;
     this.rememberPreviousStartDate();
@@ -185,6 +187,21 @@ export class RunSettingsDialogComponent implements OnInit {
     }
   }
 
+  updateRandomPeriodAssignment(isRandomPeriodAssignment: boolean) {
+    this.clearErrorMessages();
+    this.teacherService.updateRandomPeriodAssignment(this.run.id, isRandomPeriodAssignment)
+      .subscribe((response: any) => {
+        if (response.status === 'success') {
+          this.run = response.run;
+          this.updateDataRun(this.run);
+          this.clearErrorMessages();
+          this.showConfirmMessage();
+        } else {
+          this.rollbackRandomPeriodAssignment();
+        }
+      });
+  }
+
   setDateRange() {
     this.minEndDate = this.startDate;
     this.maxStartDate = this.endDate;
@@ -196,6 +213,10 @@ export class RunSettingsDialogComponent implements OnInit {
 
   rollbackMaxStudentsPerTeam() {
     this.maxStudentsPerTeam = this.run.maxStudentsPerTeam + '';
+  }
+
+  rollbackRandomPeriodAssignment() {
+    this.isRandomPeriodAssignment = this.run.isRandomPeriodAssignment;
   }
 
   rollbackStartDate() {
@@ -254,6 +275,7 @@ export class RunSettingsDialogComponent implements OnInit {
   updateDataRun(run) {
     this.data.run.periods = run.periods;
     this.data.run.maxStudentsPerTeam = run.maxStudentsPerTeam;
+    this.data.run.isRandomPeriodAssignment = run.isRandomPeriodAssignment;
     this.data.run.startTime = run.startTime;
     this.data.run.endTime = run.endTime;
     this.data.run.lastRun = run.lastRun;

--- a/src/main/webapp/site/src/app/teacher/teacher.service.ts
+++ b/src/main/webapp/site/src/app/teacher/teacher.service.ts
@@ -22,6 +22,7 @@ export class TeacherService {
   private lastRunUrl = "api/teacher/projectlastrun";
   private addPeriodToRunUrl = "api/teacher/run/add/period";
   private deletePeriodFromRunUrl = "api/teacher/run/delete/period";
+  private updateRandomPeriodAssignmentUrl = "api/teacher/run/update/random-period-assignment";
   private updateRunStudentsPerTeamUrl =
     "api/teacher/run/update/studentsperteam";
   private updateRunStartTimeUrl = "api/teacher/run/update/starttime";
@@ -97,6 +98,7 @@ export class TeacherService {
   createRun(
     projectId: number,
     periods: string,
+    isRandomPeriodAssignment: boolean,
     maxStudentsPerTeam: number,
     startDate: number,
     endDate: number
@@ -108,6 +110,7 @@ export class TeacherService {
     let body = new HttpParams();
     body = body.set("projectId", projectId + "");
     body = body.set("periods", periods);
+    body = body.set("isRandomPeriodAssignment", isRandomPeriodAssignment + "");
     body = body.set("maxStudentsPerTeam", maxStudentsPerTeam + "");
     body = body.set("startDate", startDate + "");
     if (endDate) {
@@ -273,6 +276,17 @@ export class TeacherService {
     body = body.set("runId", runId + "");
     body = body.set("periodName", periodName);
     return this.http.post<Object>(url, body, { headers: headers });
+  }
+
+  updateRandomPeriodAssignment(runId: number, isRandomPeriodAssignment: boolean) {
+    const headers = new HttpHeaders().set(
+      "Content-Type",
+      "application/x-www-form-urlencoded"
+    );
+    let body = new HttpParams();
+    body = body.set("runId", runId + "");
+    body = body.set("isRandomPeriodAssignment", isRandomPeriodAssignment + "");
+    return this.http.post<Object>(`${this.updateRandomPeriodAssignmentUrl}`, body, { headers: headers });
   }
 
   updateRunStudentsPerTeam(runId: number, maxStudentsPerTeam: number) {

--- a/src/test/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIControllerTest.java
@@ -287,6 +287,26 @@ public class TeacherAPIControllerTest extends APIControllerTest {
   }
 
   @Test
+  public void updateRandomPeriodAssignment_RandomTrue_ReturnSuccess()
+      throws ObjectNotFoundException {
+    boolean isRandomPeriodAssignment = true;
+    expect(userService.retrieveUserByUsername(TEACHER_USERNAME)).andReturn(teacher1);
+    replay(userService);
+    expect(runService.retrieveById(runId1)).andReturn(run1);
+    runService.setRandomPeriodAssignment(run1, isRandomPeriodAssignment);
+    expectLastCall();
+    replay(runService);
+    expectGetRunMapToBeCalled();
+    replay(projectService);
+    HashMap<String, Object> response = teacherAPIController.updateRandomPeriodAssignment(
+      teacherAuth, runId1, isRandomPeriodAssignment);
+    assertEquals("success", response.get("status"));
+    verify(userService);
+    verify(runService);
+    verify(projectService);
+  }
+
+  @Test
   public void createRun_ThreePeriods_CreateRun() throws Exception {
     expect(userService.retrieveUserByUsername(TEACHER_USERNAME)).andReturn(teacher1);
     replay(userService);
@@ -296,6 +316,7 @@ public class TeacherAPIControllerTest extends APIControllerTest {
     replay(projectService);
     Long projectId = 1L;
     String periods = "1,2,free";
+    boolean isRandomPeriodAssignment = false;
     Integer maxStudentsPerTeam = 3;
     Long startDate = Calendar.getInstance().getTimeInMillis();
     Long endDate = null;
@@ -303,17 +324,16 @@ public class TeacherAPIControllerTest extends APIControllerTest {
     periodNamesSet.add("1");
     periodNamesSet.add("2");
     periodNamesSet.add("free");
-    expect(runService.createRun(projectId, teacher1, periodNamesSet, maxStudentsPerTeam,
-        startDate, endDate, Locale.US)).andReturn(run1);
+    expect(runService.createRun(projectId, teacher1, periodNamesSet, isRandomPeriodAssignment,
+        maxStudentsPerTeam, startDate, endDate, Locale.US)).andReturn(run1);
     replay(runService);
     teacherAPIController.createRun(teacherAuth, request, projectId, periods,
-        maxStudentsPerTeam, startDate, endDate);
+        isRandomPeriodAssignment, maxStudentsPerTeam, startDate, endDate);
     verify(userService);
     verify(request);
     verify(projectService);
     verify(runService);
   }
-
 
   @Test
   public void createTeacherAccount_WithGoogleUserId_CreateUser()


### PR DESCRIPTION
This PR requires a database change: 
```
alter table `wise_database`.`runs` add column `isRandomPeriodAssignment` bit(1) not null default 0 after `end_time`;
```

Please test the following:

**As teacher**
- can create a run with/without "randomly assign students to periods" option
- can edit a run with/without "randomly assign students to periods" option (use the "Edit Settings"  drop-down option in the main home page run listing view)

**As student**
- adding unit that is configured to randomly assign students to periods should assign a period randomly upon entering the access code and NOT allow student to modify the period selection
- adding a unit that is NOT configured to randomly assign students to periods should allow the student to select a period upon entering the access code

Resolves #52