### PR TITLE
Added option to allow/disallow commenting on discussion posts

### DIFF
--- a/src/main/webapp/wise5/components/discussion/authoring.html
+++ b/src/main/webapp/wise5/components/discussion/authoring.html
@@ -219,6 +219,14 @@
     <br/>
     <md-input-container style='margin-top: 0; margin-bottom: 0;'>
       <md-checkbox class='md-primary'
+                   ng-model='discussionController.authoringComponentContent.isCommentingAllowed'
+                   ng-change='discussionController.authoringViewComponentChanged()'>
+        {{ ::'discussion.allowCommenting' | translate }}
+      </md-checkbox>
+    </md-input-container>
+    <br/>
+    <md-input-container style='margin-top: 0; margin-bottom: 0;'>
+      <md-checkbox class='md-primary'
                    ng-model='discussionController.authoringComponentContent.isVotingAllowed'
                    ng-change='discussionController.authoringViewComponentChanged()'>
         {{ ::'discussion.allowVoting' | translate }}

--- a/src/main/webapp/wise5/components/discussion/classResponse.html
+++ b/src/main/webapp/wise5/components/discussion/classResponse.html
@@ -51,7 +51,7 @@
     </div>
   </div>
   <md-divider></md-divider>
-  <div class='discussion-comments'>
+  <div class='discussion-comments' ng-if='classResponseCtrl.iscommentingallowed'>
     <div class='discussion-comments__contents' ng-if='classResponseCtrl.response.replies.length'>
       <md-subheader class='md-no-sticky discussion-comments__header'>
         <span ng-if='classResponseCtrl.response.replies.length == 1'>

--- a/src/main/webapp/wise5/components/discussion/classResponse.ts
+++ b/src/main/webapp/wise5/components/discussion/classResponse.ts
@@ -13,7 +13,8 @@ const ClassResponse = {
     createunvoteannotation: '&',
     studentdatachanged: '&',
     isdisabled: '<',
-    isvotingallowed: '<'
+    isvotingallowed: '<',
+    iscommentingallowed: '<'
   },
   templateUrl: 'wise5/components/discussion/classResponse.html',
   controller: 'ClassResponseController as classResponseCtrl'

--- a/src/main/webapp/wise5/components/discussion/classResponseController.ts
+++ b/src/main/webapp/wise5/components/discussion/classResponseController.ts
@@ -27,6 +27,9 @@ class ClassResponseController {
   @Input()
   isvotingallowed: boolean;
 
+  @Input()
+  iscommentingallowed: boolean = true;
+
   $scope: any;
   $filter: any;
   $translate: any;

--- a/src/main/webapp/wise5/components/discussion/discussionAuthoringController.ts
+++ b/src/main/webapp/wise5/components/discussion/discussionAuthoringController.ts
@@ -61,6 +61,9 @@ class DiscussionAuthoringController extends DiscussionController {
       $mdMedia
     );
     this.allowedConnectedComponentTypes = [{ type: 'Discussion' }];
+    if (this.authoringComponentContent.isCommentingAllowed == null) {
+      this.authoringComponentContent.isCommentingAllowed = true;
+    }
   }
 
   authoringConnectedComponentTypeChanged(connectedComponent) {

--- a/src/main/webapp/wise5/components/discussion/discussionController.ts
+++ b/src/main/webapp/wise5/components/discussion/discussionController.ts
@@ -168,6 +168,9 @@ class DiscussionController extends ComponentController {
     this.registerAnnotationReceivedListener();
     this.initializeWatchMdMedia();
     this.broadcastDoneRenderingComponent();
+    if (this.componentContent.isCommentingAllowed == null) {
+      this.componentContent.isCommentingAllowed = true;
+    }
   }
 
   isConnectedComponentShowWorkMode() {

--- a/src/main/webapp/wise5/components/discussion/discussionService.ts
+++ b/src/main/webapp/wise5/components/discussion/discussionService.ts
@@ -56,6 +56,7 @@ class DiscussionService extends ComponentService {
     const component: any = super.createComponent();
     component.type = 'Discussion';
     component.prompt = this.$translate('ENTER_PROMPT_HERE');
+    component.isCommentingAllowed = true;
     component.isStudentAttachmentEnabled = true;
     component.gateClassmateResponses = true;
     component.isVotingAllowed = false;

--- a/src/main/webapp/wise5/components/discussion/i18n/i18n_en.json
+++ b/src/main/webapp/wise5/components/discussion/i18n/i18n_en.json
@@ -1,4 +1,5 @@
 {
+  "discussion.allowCommenting": "Students can comment on posts",
   "discussion.allowUploadedImagesInPosts": "Students can upload and use images in their posts",
   "discussion.allowVoting": "Students can vote on posts",
   "discussion.areYouSureYouWantToDeleteThisPost": "Are you sure you want to delete this post?",

--- a/src/main/webapp/wise5/components/discussion/index.html
+++ b/src/main/webapp/wise5/components/discussion/index.html
@@ -149,6 +149,7 @@
                   createunvoteannotation='discussionController.createunvoteannotation(componentState)'
                   studentdatachanged='studentdatachanged()'
                   isdisabled='::discussionController.isDisabled'
+                  iscommentingallowed='::discussionController.componentContent.isCommentingAllowed'
                   isvotingallowed='::discussionController.isVotingAllowed()'
                   class='post animate-repeat'>
               </class-response>
@@ -165,6 +166,7 @@
                   createunvoteannotation='discussionController.createunvoteannotation(componentState)'
                   studentdatachanged='studentdatachanged()'
                   isdisabled='::discussionController.isDisabled'
+                  iscommentingallowed='::discussionController.componentContent.isCommentingAllowed'
                   isvotingallowed='::discussionController.isVotingAllowed()'
                   class='post animate-repeat'>
               </class-response>
@@ -182,6 +184,7 @@
                   createunvoteannotation='discussionController.createunvoteannotation(componentState)'
                   studentdatachanged='studentdatachanged()'
                   isdisabled='::discussionController.isDisabled'
+                  iscommentingallowed='::discussionController.componentContent.isCommentingAllowed'
                   isvotingallowed='::discussionController.isVotingAllowed()'
                   class='animate-repeat'
                   style='display: block;'>


### PR DESCRIPTION
In the authoring tool:
- test that you can enable/disable commenting on discussion posts. The default is enabled.

In the student tool, discussion component:
- test that the commenting feature is displayed/hidden based on the setting.

Closes #66