### PR TITLE
Implemented unlocking score constraint in real-time

### DIFF
--- a/src/main/webapp/wise5/authoringTool/node/node.html
+++ b/src/main/webapp/wise5/authoringTool/node/node.html
@@ -524,10 +524,10 @@
                   <span class="node-select__text" style="color: red">{{ ::'pleaseChooseAComponent' | translate }}</span>
                 </span>
               </md-option>
-              <md-option ng-repeat="component in ::projectController.getComponentsByNodeId(criteria.params.nodeId) track by $index"
+              <md-option ng-repeat="component in projectController.getComponentsByNodeId(criteria.params.nodeId) track by $index"
                          ng-value="component.id">
                 <span layout="row" layout-align="start center">
-                  <span class="node-select__text">{{::($index + 1)}}. {{::component.type}} ({{ ::'prompt' | translate }}: {{::component.prompt}})</span>
+                  <span class="node-select__text">{{($index + 1)}}. {{component.type}} ({{ 'prompt' | translate }}: {{component.prompt}})</span>
                 </span>
               </md-option>
             </md-select>

--- a/src/main/webapp/wise5/authoringTool/node/nodeAuthoringController.ts
+++ b/src/main/webapp/wise5/authoringTool/node/nodeAuthoringController.ts
@@ -183,7 +183,7 @@ class NodeAuthoringController {
             text: this.$translate('step')
           },
           {
-            value: 'component',
+            value: 'componentId',
             text: this.$translate('component')
           },
           {

--- a/src/main/webapp/wise5/services/studentDataService.ts
+++ b/src/main/webapp/wise5/services/studentDataService.ts
@@ -757,6 +757,7 @@ export class StudentDataService {
     } else {
       this.upgrade.$injector.get('$rootScope').$broadcast('annotationReceived', { annotation: annotation });
     }
+    this.updateNodeStatuses();
   }
 
   saveComponentEvent(component, category, event, data) {


### PR DESCRIPTION
Also fixed AT issue that prevented author from selecting component for score constraint. 

Test that you can unlock a constraint based on score from the teacher in real time.

Set up:
1. In the AT, open a unit that is used for a run.
2. Go to advanced view for the step that you want to lock (step S1), and click on "edit constraints"
3. Add a constraint:
- action = "Make this node not visitable"
- removal conditional = "any"
- Removal Criteria
-- Removal Criterial name: "score"
-- Step: choose the step that contains the component that you will be grading ("step S2")
-- Component: choose the component that you will be grading ("component S2-C")
-- Score(s): a number, like 5, or multiple numbers separated by a comma ("score X")

![Screen Shot 2020-09-10 at 9 13 14 AM](https://user-images.githubusercontent.com/119416/92760814-e3e5c280-f345-11ea-9a6f-e294c5932393.png)

4. As a student, do some work on component S2-C, and try to go to the locked step S1. You shouldn't be able to visit the step, and see a dialog saying that you need to get a score of X on the step S2.
5. In the grading view, give the student the score of X for component S2-C.
6. In the student view, try to go to the locked step S1 again. This time, you should be able to advance.

Closes #67