### PR TITLE
Added option to discuss with classmates in different periods

### DIFF
--- a/src/main/webapp/wise5/components/discussion/authoring.html
+++ b/src/main/webapp/wise5/components/discussion/authoring.html
@@ -5,6 +5,15 @@
       <h6>{{ ::'advancedAuthoringOptions' | translate }}</h6>
     </div>
     <div>
+      <md-input-container style='margin-top: 0; margin-bottom: 0;'>
+        <md-checkbox class='md-primary'
+                     ng-model='discussionController.authoringComponentContent.isSharedAcrossAllPeriods'
+                     ng-change='discussionController.authoringViewComponentChanged()'>
+          {{ ::'discussion.discussAcrossAllPeriods' | translate }}
+        </md-checkbox>
+      </md-input-container>
+    </div>
+    <div>
       <md-input-container style='margin-right: 20px; width: 150px; height: 25px;'>
         <label>{{ ::'MAX_SCORE' | translate }}</label>
         <input type='number'

--- a/src/main/webapp/wise5/components/discussion/discussionController.ts
+++ b/src/main/webapp/wise5/components/discussion/discussionController.ts
@@ -397,12 +397,15 @@ class DiscussionController extends ComponentController {
     this.destroyAnnotationReceivedListener =
     this.$rootScope.$on('annotationReceived', (event, annotation) => {
       if (this.isForThisComponent(annotation)) {
-        const annotations = this.componentAnnotations.concat(annotation);
-        this.componentAnnotations =
-            this.filterLatestAnnotationsByWorkgroup(annotations);
+        this.addAnnotation(annotation);
         this.topLevelResponses = this.getLevel1Responses();
       }
     });
+  }
+
+  addAnnotation(annotation: any) {
+    const annotations = this.componentAnnotations.concat(annotation);
+    this.componentAnnotations = this.filterLatestAnnotationsByWorkgroup(annotations);
   }
 
   isWorkFromClassmate(componentState) {
@@ -844,7 +847,9 @@ class DiscussionController extends ComponentController {
     };
     const annotation = this.AnnotationService.createVoteAnnotation(
         runId, periodId, nodeId, componentId, fromWorkgroupId, toWorkgroupId, studentWorkId, data);
-    return this.AnnotationService.saveAnnotation(annotation);
+    return this.AnnotationService.saveAnnotation(annotation).then(() => {
+      this.addAnnotation(annotation);
+    });
   }
 
   /**
@@ -869,7 +874,9 @@ class DiscussionController extends ComponentController {
     };
     const annotation = this.AnnotationService.createVoteAnnotation(
         runId, periodId, nodeId, componentId, fromWorkgroupId, toWorkgroupId, studentWorkId, data);
-    return this.AnnotationService.saveAnnotation(annotation);
+    return this.AnnotationService.saveAnnotation(annotation).then(() => {
+      this.addAnnotation(annotation);
+    });
   }
 
   /**
@@ -894,7 +901,9 @@ class DiscussionController extends ComponentController {
     };
     const annotation = this.AnnotationService.createVoteAnnotation(
         runId, periodId, nodeId, componentId, fromWorkgroupId, toWorkgroupId, studentWorkId, data);
-    return this.AnnotationService.saveAnnotation(annotation);
+    return this.AnnotationService.saveAnnotation(annotation).then(() => {
+      this.addAnnotation(annotation);
+    });
   }
 
   /**

--- a/src/main/webapp/wise5/components/discussion/discussionController.ts
+++ b/src/main/webapp/wise5/components/discussion/discussionController.ts
@@ -440,7 +440,8 @@ class DiscussionController extends ComponentController {
 
   getClassmateResponses(components = [{ nodeId: this.nodeId, componentId: this.componentId }]) {
     const runId = this.ConfigService.getRunId();
-    const periodId = this.ConfigService.getPeriodId();
+    const periodId = this.componentContent.isSharedAcrossAllPeriods ? null :
+        this.ConfigService.getPeriodId();
     this.DiscussionService.getClassmateResponses(runId, periodId, components)
         .then(({studentWorkList, annotations}) => {
       this.componentAnnotations = this.filterLatestAnnotationsByWorkgroup(annotations);

--- a/src/main/webapp/wise5/components/discussion/i18n/i18n_en.json
+++ b/src/main/webapp/wise5/components/discussion/i18n/i18n_en.json
@@ -6,6 +6,7 @@
   "discussion.areYouSureYouWantToShowThisPost": "Are you sure you want to show this post?",
   "discussion.comments": "Comments",
   "discussion.componentTypeLabel": "Discussion",
+  "discussion.discussAcrossAllPeriods": "Students can discuss with students from all periods, not just their own",
   "discussion.gateClassmateResponses": "Students must create a post before viewing classmates' posts",
   "discussion.post": "Post",
   "discussion.repliedToADiscussionYouWereIn": "{{usernames}} replied to a discussion you were in!",


### PR DESCRIPTION
Test the following:

- In discussion component authoring -> advanced view (accessible via the wrench icon), the author can enable/disable cross-period discussion via the option "Students can discuss with students from all periods, not just their own" 
- The student can see and comment on students' posts from all other periods when the option is enabled.

Note: 
- New posts/comments from students in other periods do **not** show up in real-time right now. This would take a bit more work, and should be done in a separate issue. New posts/comments from students in other periods will appear once the student re-visits the step (goes to another step and comes back), or refreshes the page. 
- New posts/comments from students in the same period will appear in real-time as before.

Closes #65