### PR TITLE
Fixed student request help approval issue

### DIFF
--- a/src/main/java/org/wise/portal/spring/data/redis/RedisMessageSubscriber.java
+++ b/src/main/java/org/wise/portal/spring/data/redis/RedisMessageSubscriber.java
@@ -65,14 +65,10 @@ public class RedisMessageSubscriber implements MessageListener {
       } else if (messageJSON.get("type").equals("goToNextNode")) {
         WebSocketMessage webSockeMessage = new WebSocketMessage("goToNextNode",
             "");
-        simpMessagingTemplate.convertAndSend(messageJSON.getString("topic"),
-            webSockeMessage);
         simpMessagingTemplate.convertAndSend(messageJSON.getString("topic"), webSockeMessage);
       } else if (messageJSON.get("type").equals("node")) {
         WebSocketMessage webSockeMessage = new WebSocketMessage("node",
             messageJSON.getString("node"));
-        simpMessagingTemplate.convertAndSend(messageJSON.getString("topic"),
-            webSockeMessage);
         simpMessagingTemplate.convertAndSend(messageJSON.getString("topic"), webSockeMessage);
       } else if (messageJSON.get("type").equals("tagsToWorkgroup")) {
         WebSocketMessage webSockeMessage = new WebSocketMessage("tagsToWorkgroup", messageJSON.getString("tags"));


### PR DESCRIPTION
Test that approving student's request for help sends the students to the very next node, instead of two steps ahead.

Also fixed a similar issue where node was being sent multiple times when teacher locks/unlocks a lesson. This didn't result in any observable problems.

Closes #83