### PR TITLE
Allow teachers to view all discussion posts

### DIFF
--- a/src/main/webapp/wise5/components/discussion/classResponse.html
+++ b/src/main/webapp/wise5/components/discussion/classResponse.html
@@ -26,10 +26,12 @@
       ng-src='{{::attachment.iconURL}}' alt='Image' class='discussion-post__attachment' />
     <div layout='row' layout-align='end center' ng-if='::classResponseCtrl.isvotingallowed'>
         <md-button ng-class="classResponseCtrl.isUpvoteClicked ? 'md-accent' : ''"
+          ng-disabled="classResponseCtrl.mode === 'showAllPosts'"
           ng-click='classResponseCtrl.upvoteClicked(classResponseCtrl.response)'>
         <md-icon>thumb_up</md-icon>
         </md-button>
         <md-button ng-class="classResponseCtrl.isDownvoteClicked ? 'md-accent' : ''"
+          ng-disabled="classResponseCtrl.mode === 'showAllPosts'"
           ng-click='classResponseCtrl.downvoteClicked(classResponseCtrl.response)'>
         <md-icon>thumb_down</md-icon>
       </md-button>

--- a/src/main/webapp/wise5/components/discussion/i18n/i18n_en.json
+++ b/src/main/webapp/wise5/components/discussion/i18n/i18n_en.json
@@ -13,6 +13,7 @@
   "discussion.post": "Post",
   "discussion.repliedToADiscussionYouWereIn": "{{usernames}} replied to a discussion you were in!",
   "discussion.reply": "Reply",
+  "discussion.seeEntireClassDiscussion": "See entire class discussion",
   "discussion.shareDiscussionPostWithClass": "Share with class...",
   "discussion.sortOption.leastPopular": "Least Popular -> Most Popular",
   "discussion.sortOption.mostPopular": "Most Popular -> Least Popular",

--- a/src/main/webapp/wise5/components/discussion/index.html
+++ b/src/main/webapp/wise5/components/discussion/index.html
@@ -24,6 +24,7 @@
                       createupvoteannotation='discussionController.createupvoteannotation(componentState)'
                       createdownvoteannotation='discussionController.createdownvoteannotation(componentState)'
                       createunvoteannotation='discussionController.createunvoteannotation(componentState)'
+                      isvotingallowed='::discussionController.isVotingAllowed()'
                       studentdatachanged='studentdatachanged()'
                       class='post'>
                   </class-response>
@@ -31,6 +32,8 @@
               </div>
             </div>
           </div>
+          <span flex></span>
+          <a style="margin-top: 10px" ng-click="discussionController.showEntireDiscussion($event)" translate="discussion.seeEntireClassDiscussion"></a>
           <span flex></span>
           <component-revisions-info node-id='discussionController.nodeId'
               component-id='discussionController.componentId'


### PR DESCRIPTION
The teacher can now view all the discussion posts for the current period selected (specific periods, or all periods). I didn't implement the interactions within this view (see below for details).

How to test:
1. Open the grading tool, and go to grade-by-step view
2. Open a discussion component for a particular workgroup. 
3. Under all the posts that the workgroup has done, there is a link to "See entire class discussion". Click on the link. This should open a popup
4. Test that:
   1. you can see all of the students' posts for the current period (the current period should match the period selection drop-down). 
   2. you can sort by latest, oldest, most-votes, and least votes
   3. other interactions (deleting, undeleting, voting posts) are not enabled in the popup for now. I think we should refactor the code a bit before adding those functionalities. You can still perform those functions in the original grade-by-workgroup view for each workgroup.
   4. you can close the popup by hitting escape, or clicking on the close button or outside the popup window.

Closes #94